### PR TITLE
Add live-build package to dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ echo -e "
 "
 
 apt-get update
-apt-get install -y binutils zstd
+apt-get install -y binutils zstd live-build
 dpkg -i ./debs/*.deb
 
 build () {


### PR DESCRIPTION
Add `live-build` package to dependencies for make possible building iso image in the docker container based on `debian:latest` docker image.

```
docker run --privileged -i -v /proc:/proc \
      -v ${PWD}:/working_dir \
      -w /working_dir \
      debian:latest \
      /bin/bash -s etc/terraform.conf < build.sh
```